### PR TITLE
Fix equality comparison for containers.

### DIFF
--- a/scope/test.h
+++ b/scope/test.h
@@ -52,14 +52,18 @@ namespace scope {
   }
 
   // eval_equal_impl for anything having std::begin and std::end overloads
-  template <typename ExceptionType, typename ExpSequenceT, typename ActSequenceT>
+  template <
+    typename ExceptionType,
+    typename ExpSequenceT,
+    typename ActSequenceT
+  >
   auto eval_equal_impl(ExpSequenceT&& e, ActSequenceT&& a, int, const char* const file, int line, const char* msg = "") -> decltype(std::begin(e), std::end(e), std::begin(a), std::end(a), void()) {
     const auto abeg = std::begin(a);
     const auto aend = std::end(a);
     const auto ebeg = std::begin(e);
     const auto eend = std::end(e);
-    const size_t elen = eend - ebeg;
-    const size_t alen = aend - abeg;
+    const size_t elen = std::distance(ebeg, eend);
+    const size_t alen = std::distance(abeg, aend);
 
     if (alen != elen) {
       std::ostringstream buf;
@@ -76,8 +80,10 @@ namespace scope {
       if (*msg) {
         buf << msg << " ";
       }
-      buf << "Expected[" << (mis.first - ebeg) << "]: " << *mis.first
-          << ", Actual[" << (mis.second - abeg) << "]: " << *mis.second;
+      buf << "Expected["
+          << std::distance(ebeg, mis.first) << "]: " << *mis.first
+          << ", Actual["
+          << std::distance(abeg, mis.second) << "]: " << *mis.second;
       throw ExceptionType(file, line, buf.str().c_str());
     }
   }
@@ -120,8 +126,8 @@ namespace scope {
   >
   void eval_equal(const ExpectedT& e, const ActualT& a, const char* const file, int line, const char* msg = "") {
     eval_equal_impl<ExceptionType>(
-      std::forward<const ExpectedT>(e),
-      std::forward<const ActualT>(a),
+      std::forward<const ExpectedT&>(e),
+      std::forward<const ActualT&>(a),
       0, // prefer sequence overload, because 0 is an int
       file, line, msg
     );


### PR DESCRIPTION
Use std::distance instead of operator- for determining distance of iterators from begining of container.