### PR TITLE
Fix GCC compiler error/unused parameter warning

### DIFF
--- a/scope/test.h
+++ b/scope/test.h
@@ -107,7 +107,7 @@ namespace scope {
   template <
     typename TupleT
   >
-  const char* tupleGetOrDefault(TupleT&& tup, std::integral_constant<size_t, std::tuple_size<typename std::remove_reference<TupleT>::type>::value>)
+  const char* tupleGetOrDefault(TupleT&&, std::integral_constant<size_t, std::tuple_size<typename std::remove_reference<TupleT>::type>::value>)
   {
     return "*past end*";
   }

--- a/scope/test.h
+++ b/scope/test.h
@@ -42,7 +42,7 @@ namespace scope {
 
   template<typename ExceptionType, typename ExpectedT, typename ActualT>
   auto evalEqualImpl(ExpectedT&& e, ActualT&& a, long, const char* const file, int line, const char* msg = "")
-   -> decltype((e == a), std::ostringstream() << e, std::ostringstream() << a, void())
+   -> decltype((e == a), std::declval<std::ostringstream&>() << e, std::declval<std::ostringstream&>() << a, void())
   {
     // it'd be good to have a CTAssert on (ExpectedT==ActualT)
     if (!(e == a)) {

--- a/test1.cpp
+++ b/test1.cpp
@@ -7,6 +7,7 @@
 
 #include <vector>
 #include <list>
+#include <set>
 
 SCOPE_TEST(simpleTest) {
   SCOPE_ASSERT(true);
@@ -74,5 +75,19 @@ SCOPE_TEST(pairEquality) {
 SCOPE_TEST(tupleEquality) {
   std::tuple<int, std::string, double> a = {5, "hello", 3.14};
   std::tuple<int, std::string, double> b = {5, "hello, world", 3.141592653};
+  SCOPE_ASSERT_EQUAL(a, b);
+}
+
+SCOPE_TEST(setEquality) {
+  std::set<std::string> a {"hello", "world"};
+  std::set<std::string> b {"hello", "world"};
+
+  SCOPE_ASSERT_EQUAL(a, b);
+}
+
+SCOPE_TEST(setInequality) {
+  std::set<std::string> a {"hello", "world"};
+  std::set<std::string> b {"hello"};
+
   SCOPE_ASSERT_EQUAL(a, b);
 }


### PR DESCRIPTION
This fixes a compilation error when using GCC in certain circumstances, and fixes an unused parameter warning.